### PR TITLE
Fix jackson classloading issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <dependency>
             <groupId>org.camunda.bpm</groupId>
             <artifactId>camunda-engine-plugin-spin</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.camunda.spin</groupId>
@@ -68,6 +69,7 @@
         <dependency>
             <groupId>org.camunda.spin</groupId>
             <artifactId>camunda-spin-dataformat-json-jackson</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax</groupId>

--- a/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
+++ b/src/main/webapp/WEB-INF/jboss-deployment-structure.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jboss-deployment-structure>
     <deployment>
+        <exclude-subsystems>
+            <subsystem name="jaxrs" />
+        </exclude-subsystems>
         <dependencies>
             <module name="com.fasterxml.jackson.core.jackson-databind" slot="2.5.3" export="true" />
         </dependencies>


### PR DESCRIPTION
Wildfly adds resteasy dependencies to all deployments [per default](https://github.com/wildfly/wildfly/blob/8.2.1.Final/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsDependencyProcessor.java#L74-L87). These dependencies export jackson main slot modules as dependency. So if you want to use an other version of the jackson module you have to exclude these dependecies for example by excluding the jaxrs subsystem.
